### PR TITLE
workflows: Fix build naming

### DIFF
--- a/.github/workflows/deltaquery.dockerfiles.yaml
+++ b/.github/workflows/deltaquery.dockerfiles.yaml
@@ -1,4 +1,4 @@
-name: Build metabase
+name: Build deltaquery
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
# Description

Fix github workflows build naming "Build metabase" to "Build deltaquery"

# Related Issue(s)

<!---
- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
