### PR TITLE
Add optional schema argument to compute execution

### DIFF
--- a/src/compute.rs
+++ b/src/compute.rs
@@ -1,6 +1,7 @@
 use crate::configs::{DQComputeConfig, DQFilesystemConfig};
 use crate::error::DQError;
 use arrow::array::RecordBatch;
+use arrow::datatypes::Schema;
 use async_trait::async_trait;
 use once_cell::sync::Lazy;
 use sqlparser::ast::Statement;
@@ -15,6 +16,7 @@ pub trait DQCompute: Send + Sync {
     async fn execute(
         &mut self,
         statement: &Statement,
+        schema: Option<Schema>,
         files: Vec<String>,
     ) -> Result<Vec<RecordBatch>, DQError>;
 }

--- a/src/computes/duckdb/mod.rs
+++ b/src/computes/duckdb/mod.rs
@@ -2,6 +2,7 @@ use crate::compute::{DQCompute, DQComputeFactory};
 use crate::configs::{DQComputeConfig, DQFilesystemConfig};
 use crate::error::DQError;
 use arrow::array::RecordBatch;
+use arrow::datatypes::Schema;
 use async_trait::async_trait;
 use duckdb::{params, Connection};
 use sqlparser::ast::{SetExpr, Statement, TableFactor};
@@ -38,6 +39,7 @@ impl DQCompute for DQDuckDBCompute {
     async fn execute(
         &mut self,
         statement: &Statement,
+        _schema: Option<Schema>,
         files: Vec<String>,
     ) -> Result<Vec<RecordBatch>, DQError> {
         let mut batches = Vec::new();

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,5 +1,6 @@
 use crate::configs::{DQFilesystemConfig, DQStorageConfig, DQTableConfig};
 use crate::error::DQError;
+use arrow::datatypes::Schema;
 use async_trait::async_trait;
 use once_cell::sync::Lazy;
 use sqlparser::ast::Statement;
@@ -13,6 +14,8 @@ static STORAGE_FACTORIES: Lazy<Mutex<HashMap<String, Box<dyn DQStorageFactory>>>
 pub trait DQStorage: Send + Sync {
     async fn update(&mut self) -> Result<(), DQError>;
     async fn execute(&mut self, statement: &Statement) -> Result<Vec<String>, DQError>;
+
+    fn schema(&self) -> Option<Schema>;
 }
 
 #[async_trait]

--- a/src/storages/delta/mod.rs
+++ b/src/storages/delta/mod.rs
@@ -291,6 +291,10 @@ impl DQStorage for DQDeltaStorage {
 
         Ok(files)
     }
+
+    fn schema(&self) -> Option<Schema> {
+        Some(self.schema.clone())
+    }
 }
 
 pub struct DQDeltaStorageFactory {}

--- a/src/table.rs
+++ b/src/table.rs
@@ -22,7 +22,8 @@ impl DQTable {
 
     pub async fn execute(&mut self, statement: &Statement) -> Result<Vec<RecordBatch>, DQError> {
         let files = self.storage.execute(statement).await?;
-        let batches = self.compute.execute(statement, files).await?;
+        let schema = self.storage.schema();
+        let batches = self.compute.execute(statement, schema, files).await?;
 
         Ok(batches)
     }


### PR DESCRIPTION
# Description

Add optional schema argument to compute execution for reusing storage's schema.

# Related Issue(s)

# Documentation