### PR TITLE
Add type casting to utf8 if predicate field is not utf8

### DIFF
--- a/src/storages/delta/mod.rs
+++ b/src/storages/delta/mod.rs
@@ -237,16 +237,8 @@ impl DQStorage for DQDeltaStorage {
                 SetExpr::Select(select) => {
                     if let (Some(selection), Some(batch0)) = (&select.selection, self.stats.first())
                     {
-                        let expressions = predicates::parse_expression(
-                            &selection,
-                            &self
-                                .schema
-                                .fields
-                                .iter()
-                                .map(|field| field.name().as_str())
-                                .collect(),
-                            false,
-                        );
+                        let expressions =
+                            predicates::parse_expression(&selection, &self.schema.fields, false);
 
                         log::info!("filters={:#?}", expressions);
 

--- a/src/storages/delta/predicates.rs
+++ b/src/storages/delta/predicates.rs
@@ -1,16 +1,17 @@
+use arrow::datatypes::{DataType, Fields};
 use deltalake::datafusion::common::scalar::ScalarValue;
 use deltalake::datafusion::common::Column;
-use deltalake::datafusion::logical_expr::Expr;
+use deltalake::datafusion::logical_expr::{Cast, Expr};
 
 fn get_binary_expression_with_minmax(
     predicates: &sqlparser::ast::Expr,
-    columns: &Vec<&str>,
+    fields: &Fields,
 ) -> (Expr, Expr, Expr) {
     match predicates {
         sqlparser::ast::Expr::BinaryOp { left, right, .. } => {
-            let min = parse_expression(left, columns, false);
-            let max = parse_expression(left, columns, true);
-            let right = parse_expression(right, columns, false);
+            let min = parse_expression(left, fields, false);
+            let max = parse_expression(left, fields, true);
+            let right = parse_expression(right, fields, false);
 
             (min, max, right)
         }
@@ -18,27 +19,23 @@ fn get_binary_expression_with_minmax(
     }
 }
 
-pub fn parse_expression(
-    predicates: &sqlparser::ast::Expr,
-    columns: &Vec<&str>,
-    use_max: bool,
-) -> Expr {
+pub fn parse_expression(predicates: &sqlparser::ast::Expr, fields: &Fields, use_max: bool) -> Expr {
     match predicates {
         sqlparser::ast::Expr::BinaryOp { left, op, right } => match op {
             sqlparser::ast::BinaryOperator::And => {
-                let left = parse_expression(left, columns, use_max);
-                let right = parse_expression(right, columns, use_max);
+                let left = parse_expression(left, fields, use_max);
+                let right = parse_expression(right, fields, use_max);
 
                 left.and(right)
             }
             sqlparser::ast::BinaryOperator::Or => {
-                let left = parse_expression(left, columns, use_max);
-                let right = parse_expression(right, columns, use_max);
+                let left = parse_expression(left, fields, use_max);
+                let right = parse_expression(right, fields, use_max);
 
                 left.or(right)
             }
             sqlparser::ast::BinaryOperator::Eq => {
-                let (min, max, right) = get_binary_expression_with_minmax(predicates, columns);
+                let (min, max, right) = get_binary_expression_with_minmax(predicates, fields);
 
                 if min == max {
                     min.eq(right)
@@ -47,42 +44,58 @@ pub fn parse_expression(
                 }
             }
             sqlparser::ast::BinaryOperator::Lt => {
-                let left = parse_expression(left, columns, use_max);
-                let right = parse_expression(right, columns, use_max);
+                let left = parse_expression(left, fields, use_max);
+                let right = parse_expression(right, fields, use_max);
 
                 left.lt(right)
             }
             sqlparser::ast::BinaryOperator::LtEq => {
-                let left = parse_expression(left, columns, use_max);
-                let right = parse_expression(right, columns, use_max);
+                let left = parse_expression(left, fields, use_max);
+                let right = parse_expression(right, fields, use_max);
 
                 left.lt_eq(right)
             }
             sqlparser::ast::BinaryOperator::Gt => {
-                let left = parse_expression(left, columns, use_max);
-                let right = parse_expression(right, columns, use_max);
+                let left = parse_expression(left, fields, use_max);
+                let right = parse_expression(right, fields, use_max);
 
                 left.gt(right)
             }
             sqlparser::ast::BinaryOperator::GtEq => {
-                let left = parse_expression(left, columns, use_max);
-                let right = parse_expression(right, columns, use_max);
+                let left = parse_expression(left, fields, use_max);
+                let right = parse_expression(right, fields, use_max);
 
                 left.gt_eq(right)
             }
             _ => unimplemented!(),
         },
         sqlparser::ast::Expr::Identifier(ident) => {
-            let name = ident.value.as_str();
-            if use_max {
-                let name_max = [name, "max"].join(".");
-                if columns.contains(&name_max.as_str()) {
-                    Expr::Column(Column::from_name(name))
+            let name = ident.value.clone();
+            let column = if use_max {
+                let name_max = [&name, "max"].join(".");
+                if fields
+                    .iter()
+                    .any(|field| field.name() == &name_max.as_str())
+                {
+                    name_max
                 } else {
-                    Expr::Column(Column::from_name(name))
+                    name
                 }
             } else {
-                Expr::Column(Column::from_name(name))
+                name
+            };
+
+            if let Some((_, field)) = fields.find(&column) {
+                if field.data_type() != &DataType::Utf8 {
+                    Expr::Cast(Cast::new(
+                        Box::new(Expr::Column(Column::from_name(column))),
+                        DataType::Utf8,
+                    ))
+                } else {
+                    Expr::Column(Column::from_name(column))
+                }
+            } else {
+                Expr::Column(Column::from_name(column))
             }
         }
         sqlparser::ast::Expr::Value(value) => match value {


### PR DESCRIPTION
# Description

Add type casting to utf8 if predicate field is not utf8.

# Related Issue(s)

# Documentation