### PR TITLE
Ignore unsupported expressions for predicates

### DIFF
--- a/src/tables/delta/predicates.rs
+++ b/src/tables/delta/predicates.rs
@@ -215,8 +215,8 @@ pub fn parse_expression(
                     None
                 }
             }
-            _ => unimplemented!(),
+            _ => None,
         },
-        _ => unimplemented!(),
+        _ => None,
     }
 }


### PR DESCRIPTION
# Description

Ignore unsupported expressions for predicates.

# Related Issue(s)

# Documentation