### PR TITLE
Use arc vector for recordbatches from compute session execution

### DIFF
--- a/src/commons/flight.rs
+++ b/src/commons/flight.rs
@@ -4,12 +4,11 @@ use arrow_flight::{FlightData, SchemaAsIpc};
 use arrow_ipc::writer::{DictionaryTracker, IpcDataGenerator, IpcWriteOptions};
 use arrow_ipc::{CompressionType, MetadataVersion};
 use arrow_schema::Schema;
-use arrow_select::concat::concat_batches;
 use std::sync::Arc;
 
 pub fn batches_to_flight_data(
     schema: &Schema,
-    batches: Vec<RecordBatch>,
+    batches: Arc<Vec<RecordBatch>>,
     compression: Option<CompressionType>,
 ) -> Result<Vec<FlightData>, Error> {
     let options = IpcWriteOptions::try_new(8, false, MetadataVersion::V5)?
@@ -52,16 +51,4 @@ pub fn batches_to_flight_data(
     stream.extend(flight_data);
     let flight_data: Vec<_> = stream.into_iter().collect();
     Ok(flight_data)
-}
-
-pub fn merge_record_batches(batches: Vec<RecordBatch>) -> Result<RecordBatch, Error> {
-    if let Some(batch0) = batches.first() {
-        let schema = batch0.schema();
-
-        let batch = concat_batches(&schema, &batches)?;
-
-        Ok(batch)
-    } else {
-        Ok(RecordBatch::new_empty(Arc::new(Schema::empty())))
-    }
 }

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use once_cell::sync::Lazy;
 use sqlparser::ast::Statement;
 use std::collections::HashMap;
+use std::sync::Arc;
 use tokio::sync::Mutex;
 
 #[allow(missing_docs)]
@@ -45,7 +46,7 @@ pub trait DQComputeSession: Send + Sync {
         &self,
         statement: &Statement,
         state: DQStateRef,
-    ) -> Result<Vec<RecordBatch>, Error>;
+    ) -> Result<Arc<Vec<RecordBatch>>, Error>;
 }
 
 #[async_trait]

--- a/src/computes/duckdb/mod.rs
+++ b/src/computes/duckdb/mod.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use duckdb::{params, Connection};
 use sqlparser::ast::{SetExpr, Statement, TableFactor};
 use std::collections::HashMap;
+use std::sync::Arc;
 use url::Url;
 
 pub struct DQDuckDBCompute {
@@ -50,7 +51,7 @@ impl DQComputeSession for DQDuckDBComputeSession {
         &self,
         statement: &Statement,
         state: DQStateRef,
-    ) -> Result<Vec<RecordBatch>, Error> {
+    ) -> Result<Arc<Vec<RecordBatch>>, Error> {
         match statement {
             Statement::Query(query) => {
                 if let SetExpr::Select(select) = query.body.as_ref() {
@@ -96,7 +97,7 @@ impl DQComputeSession for DQDuckDBComputeSession {
                                     let batches =
                                         stmt.query_arrow([])?.collect::<Vec<RecordBatch>>();
 
-                                    return Ok(batches);
+                                    return Ok(Arc::new(batches));
                                 }
                             }
                             _ => {

--- a/src/servers/flightsql/simple/mod.rs
+++ b/src/servers/flightsql/simple/mod.rs
@@ -702,6 +702,7 @@ impl FlightSqlService for FlightSqlServiceSimple {
         let batch = Self::get_dummy_batch().map_err(to_tonic_error)?;
         let schema = batch.schema();
         let batches = vec![batch];
+        let batches = Arc::new(batches);
         let flight_data =
             flight::batches_to_flight_data(schema.as_ref(), batches, Some(CompressionType::ZSTD))
                 .map_err(|e| status!("Could not convert batches", e))?

--- a/src/servers/flightsql/single/mod.rs
+++ b/src/servers/flightsql/single/mod.rs
@@ -70,7 +70,7 @@ pub struct FlightSqlServiceSingle {
     compression: Option<CompressionType>,
     endpoint: String,
 
-    handles: Arc<Mutex<HashMap<String, Vec<RecordBatch>>>>,
+    handles: Arc<Mutex<HashMap<String, Arc<Vec<RecordBatch>>>>>,
 }
 
 impl FlightSqlServiceSingle {


### PR DESCRIPTION
# Description

Use arc vector for recordbatches from compute session execution.

# Related Issue(s)

# Documentation