### PR TITLE
Use sql json type for table's partitions field

### DIFF
--- a/src/configs.rs
+++ b/src/configs.rs
@@ -25,7 +25,7 @@ pub struct DQTableConfig {
     pub storage: String,
     pub location: String,
 
-    pub partitions: Option<Vec<String>>,
+    pub partitions: Option<sqlx::types::Json<Vec<String>>>,
     pub options: Option<sqlx::types::Json<HashMap<String, String>>>,
 
     pub created_at: Option<NaiveDateTime>,


### PR DESCRIPTION
# Description

Use sql json type for table's partitions field.

# Related Issue(s)

# Documentation